### PR TITLE
Bugfix: Renaming Migration Logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tcode-api"
-version = "1.37.2"
+version = "1.37.3"
 description = "Python implementation of Trilobio's TCode API"
 authors = [{ name = "Trilobio", email = "hello@trilo.bio" }]
 readme = "README.md"

--- a/scripts/calibrate_tool.py
+++ b/scripts/calibrate_tool.py
@@ -245,8 +245,8 @@ def main(
             tc.ADD_PIPETTE_TIP_GROUP(
                 id=pipette_tip_group_id,
                 descriptor=tc.PipetteTipGroupDescriptor(
-                    row_count=channel_count,
-                    column_count=1,
+                    row_count=1,
+                    column_count=channel_count,
                 ),
             )
         )

--- a/src/tcode_api/api/compat.py
+++ b/src/tcode_api/api/compat.py
@@ -446,6 +446,7 @@ def load_api_object(
             msg="Unable to find expected key 'type' in command schema",
             data=data,
         ) from err
+
     try:
         schema_version = data["schema_version"]
     except KeyError:
@@ -499,7 +500,13 @@ def load_api_object(
         data = migrator(data)
 
     try:
-        return context.schema_registry.build_instance(data=data, key=new_name)
+        new_data = {}
+        for key, value in data.items():
+            if key == "type":
+                new_data[key] = new_name
+            else:
+                new_data[key] = value
+        return context.schema_registry.build_instance(data=new_data, key=new_name)
     except ValidationError as err:
         raise InvalidDataError(
             msg=f"Data failed validation against schema '{new_name}' version '{schema_version}'.",

--- a/src/tcode_api/schemas/registry.py
+++ b/src/tcode_api/schemas/registry.py
@@ -18,13 +18,18 @@ class BuilderNotFoundError(Exception):
     """
 
     def __init__(
-        self, factory_key: RegistryKey, builder_keys: list[RegistryKey], message: str | None = None
+        self,
+        factory_name: str,
+        factory_key: RegistryKey,
+        builder_keys: list[RegistryKey],
+        message: str | None = None,
     ) -> None:
         if message is None:
             message = (
-                f"{self.__class__.__name__} has no builder registered with {factory_key}; "
+                f"{factory_name} has no builder registered with {factory_key}; "
                 f"available builders: {', '.join(builder_keys)}"
             )
+        self.factory_name = factory_name
         self.factory_key = factory_key
         self.builder_keys = builder_keys
         super().__init__(message)
@@ -70,6 +75,7 @@ class MigrationRegistry:
             return self._migrators[key]
         except KeyError as err:
             raise BuilderNotFoundError(
+                factory_name=self.__class__.__name__,
                 factory_key=key,
                 builder_keys=list(self._migrators.keys()),
             ) from err
@@ -183,6 +189,7 @@ class SchemaRegistry:
             return self._builders[key]
         except KeyError as err:
             raise BuilderNotFoundError(
+                factory_name=self.__class__.__name__,
                 factory_key=key,
                 builder_keys=list(self._builders.keys()),
             ) from err

--- a/uv.lock
+++ b/uv.lock
@@ -1344,7 +1344,7 @@ wheels = [
 
 [[package]]
 name = "tcode-api"
-version = "1.37.2"
+version = "1.37.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
- Fix factory name showing up improperly in some errors
- calibrate_tool script was making bad PipetteTipGroups
- migration logic in compat.py was inappropriately raising an invalid schema error