### PR TITLE
Id --> SerialNumber Query API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Format: [Semantic Versioning](https://semver.org)
 
 ---
 
-## [Unreleased]
+## [1.40.0]
 ### Added
 - `TCodeServicerClient.serial_number_lookup` method
 - `SerialNumberLookupRequest`, `SerialNumberLookupResponse`, `SerialNumberLookupResult` models for serial number lookup API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: [Semantic Versioning](https://semver.org)
 
 ## [Unreleased]
 ### Added
+- `TCodeServicerClient.serial_number_lookup` method
 - `SerialNumberLookupRequest`, `SerialNumberLookupResponse`, `SerialNumberLookupResult` models for serial number lookup API.
     - API intended to fetch serial numbers of entities resolved to ids by tcode service
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented here.
+Format: [Semantic Versioning](https://semver.org)
+
+---
+
+## [Unreleased]
+### Added
+- `SerialNumberLookupRequest`, `SerialNumberLookupResponse`, `SerialNumberLookupResult` models for serial number lookup API.
+    - API intended to fetch serial numbers of entities resolved to ids by tcode service
+
+### Fixed
+
+### Refactored
+
+---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tcode-api"
-version = "1.39.0"
+version = "1.40.0"
 description = "Python implementation of Trilobio's TCode API"
 authors = [{ name = "Trilobio", email = "hello@trilo.bio" }]
 readme = "README.md"

--- a/src/tcode_api/servicer/__init__.py
+++ b/src/tcode_api/servicer/__init__.py
@@ -1,4 +1,4 @@
-"""tcode_api.servicer submoduler API."""
+"""tcode_api.servicer submodule API."""
 
 from tcode_api.servicer.client import TCodeServicerClient
 from tcode_api.servicer.servicer_api import (
@@ -13,6 +13,9 @@ from tcode_api.servicer.servicer_api import (
     ScheduleCommandRequest,
     ScheduleCommandResponse,
     ScheduleCommandsRequest,
+    SerialNumberLookupRequest,
+    SerialNumberLookupResponse,
+    SerialNumberLookupResult,
     TCodeCommandSchedulingReport,
     TCodeSchedulingReport,
 )
@@ -29,6 +32,9 @@ __all__ = [
     "ScheduleCommandRequest",
     "ScheduleCommandResponse",
     "ScheduleCommandsRequest",
+    "SerialNumberLookupRequest",
+    "SerialNumberLookupResponse",
+    "SerialNumberLookupResult",
     "TCodeCommandSchedulingReport",
     "TCodeSchedulingReport",
     "TCodeServicerClient",

--- a/src/tcode_api/servicer/client.py
+++ b/src/tcode_api/servicer/client.py
@@ -19,6 +19,7 @@ from tcode_api.servicer.servicer_api import (
     GetStatusResponse,
     ScheduleCommandRequest,
     ScheduleCommandResponse,
+    SerialNumberLookupResponse,
 )
 from tcode_api.types import Matrix
 from tcode_api.utilities import generate_id, mm, rad
@@ -173,6 +174,28 @@ class TCodeServicerClient:
         )
         rsp.raise_for_status()
         return GetStatusResponse.model_validate_json(rsp.text)
+
+    def serial_number_lookup(self, id: str) -> str:
+        """Look up the serial number associated with a given TCode id.
+
+        :param id: The TCode id to look up.
+
+        :returns: The serial number associated with the given TCode id.
+        """
+        rsp = requests.get(
+            f"{self.servicer_url}/{self.tcode_api_version}/serial_number_lookup",
+            params={"id": id},
+            timeout=self.timeout,
+        )
+        rsp.raise_for_status()
+        rsp_valid = SerialNumberLookupResponse.model_validate_json(rsp.text)
+        result = rsp_valid.results[id]
+        if result.result.success:
+            assert result.serial_number is not None  # mypy type narrowing
+            return result.serial_number
+        raise ValueError(
+            f"Serial number lookup failed for id={id}: {result.result.message} (see debug logs for details)"
+        )
 
     def schedule_command(
         self, id: str, command: tc.TCode, tcode_api_version: str | None = None

--- a/src/tcode_api/servicer/servicer_api.py
+++ b/src/tcode_api/servicer/servicer_api.py
@@ -158,6 +158,35 @@ class ExitTeachModeResponse(BaseModel):
     transform: Matrix
 
 
+class SerialNumberLookupRequest(BaseModel):
+    """tcode-servicer serial_number_lookup endpoint request data structure."""
+
+    ids: list[str] = Field(
+        description="IDs to look up. Interpreted as referencing an entity with a SerialNumber (ex. a robot or tool)",
+    )
+
+
+class SerialNumberLookupResult(BaseModel):
+    """Individual result entry for a single ID lookup in the serial_number_lookup endpoint."""
+
+    serial_number: str | None = Field(
+        default=None,
+        description="Resolved serial number, or null if resolution failed for any reason (including not found).",
+        examples=["T0004V0102F01L00N003D"],
+    )
+    result: Result = Field(
+        description="Result of the lookup attempt, including success status and error details if applicable.",
+    )
+
+
+class SerialNumberLookupResponse(BaseModel):
+    """tcode-servicer serial_number_lookup endpoint response data structure."""
+
+    results: dict[str, SerialNumberLookupResult] = Field(
+        description="Mapping of input IDs to their corresponding lookup results, including resolved serial numbers and result metadata.",
+    )
+
+
 class TCodeCommandSchedulingReport(BaseModel):
     """Report from a single TCode command scheduling call."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1484,7 +1484,7 @@ wheels = [
 
 [[package]]
 name = "tcode-api"
-version = "1.39.0"
+version = "1.40.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
- `TCodeServicerClient.serial_number_lookup` method
- `SerialNumberLookupRequest`, `SerialNumberLookupResponse`, `SerialNumberLookupResult` models for serial number lookup API.
    - API intended to fetch serial numbers of entities resolved to ids by tcode service