### PR TITLE
Bugfix v1.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented here.
 Format: [Semantic Versioning](https://semver.org)
 
+## [1.40.1]
+## Fixed
+- Fix `TCodeServicerClient` requests call to tcode servicer `serial_number_lookup` endpoint
+
 ---
 
 ## [1.40.0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tcode-api"
-version = "1.40.0"
+version = "1.40.1"
 description = "Python implementation of Trilobio's TCode API"
 authors = [{ name = "Trilobio", email = "hello@trilo.bio" }]
 readme = "README.md"

--- a/src/tcode_api/servicer/client.py
+++ b/src/tcode_api/servicer/client.py
@@ -19,6 +19,7 @@ from tcode_api.servicer.servicer_api import (
     GetStatusResponse,
     ScheduleCommandRequest,
     ScheduleCommandResponse,
+    SerialNumberLookupRequest,
     SerialNumberLookupResponse,
 )
 from tcode_api.types import Matrix
@@ -182,9 +183,9 @@ class TCodeServicerClient:
 
         :returns: The serial number associated with the given TCode id.
         """
-        rsp = requests.get(
+        rsp = requests.post(
             f"{self.servicer_url}/{self.tcode_api_version}/serial_number_lookup",
-            params={"id": id},
+            json=SerialNumberLookupRequest(ids=[id]).model_dump(),
             timeout=self.timeout,
         )
         rsp.raise_for_status()

--- a/uv.lock
+++ b/uv.lock
@@ -1484,7 +1484,7 @@ wheels = [
 
 [[package]]
 name = "tcode-api"
-version = "1.40.0"
+version = "1.40.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
- Fix `TCodeServicerClient` requests call to tcode servicer `serial_number_lookup` endpoint