### PR TITLE
Add recording receiver for robot camera remote recordings

### DIFF
--- a/docs/source/api/integrator.rst
+++ b/docs/source/api/integrator.rst
@@ -40,6 +40,29 @@ The T-code used to trigger this action is
     )
 
 
+Recording receiver
+------------------
+
+Robot cameras (trilo-cam) can stream a recording to a network target instead of
+the robot's limited local storage. The recording receiver is the other side of
+that: it accepts the streamed MP4 over HTTP and writes it to disk on the fleet
+controller. Run it standalone:
+
+.. code::
+
+    python -m tcode_api.servicer.recording_receiver --directory ./recordings --port 8096
+
+then start a remote recording pointing at it, e.g. via
+:class:`tcode_api.commands.SEND_WEBHOOK` with url
+``http://<rcm>:8095/api/v1/cameras/CAM_POS_X/remote-recording/start`` and payload
+
+.. code::
+
+    {"url": "http://<fleet-controller>:8096/robot1/CAM_POS_X.mp4", "max_duration_s": 600}
+
+The request path selects the file under the receiver's directory; existing
+files are never overwritten.
+
 API Reference
 -------------
 
@@ -47,4 +70,7 @@ API Reference
     :members:
 
 .. autoclass:: tcode_api.servicer.integrator.WebHookBody
+
+.. autoclass:: tcode_api.servicer.recording_receiver.RecordingReceiver
+    :members:
 

--- a/docs/source/api/integrator.rst
+++ b/docs/source/api/integrator.rst
@@ -1,7 +1,7 @@
 T-code Integrator API
 =====================
 
-The T-code integrator is the other side of :class:`tcode_api.commands.SEND_WEBHOOK`. Here
+The T-code integrator is the other side of :class:`tcode_api.api.SEND_WEBHOOK`. Here
 is an example integration with ATC Thermocycler. The :code:`ATCThermoCycler` class came from
 `pylabrobot`_.
 
@@ -53,7 +53,7 @@ controller. Run it standalone:
     python -m tcode_api.servicer.recording_receiver --directory ./recordings --port 8096
 
 then start a remote recording pointing at it, e.g. via
-:class:`tcode_api.commands.SEND_WEBHOOK` with url
+:class:`tcode_api.api.SEND_WEBHOOK` with url
 ``http://<rcm>:8095/api/v1/cameras/CAM_POS_X/remote-recording/start`` and payload
 
 .. code::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tcode-api"
-version = "1.41.0"
+version = "1.42.0"
 description = "Python implementation of Trilobio's TCode API"
 authors = [{ name = "Trilobio", email = "hello@trilo.bio" }]
 readme = "README.md"

--- a/src/tcode_api/servicer/recording_receiver.py
+++ b/src/tcode_api/servicer/recording_receiver.py
@@ -7,7 +7,9 @@ of the robot's limited storage.
 """
 
 from pathlib import Path
+from typing import BinaryIO
 
+import anyio.to_thread
 import fastapi
 import plac  # type: ignore [import-untyped]
 import uvicorn
@@ -15,8 +17,6 @@ from fastapi import FastAPI, Request
 from starlette.requests import ClientDisconnect
 
 RECORDING_RECEIVER_DEFAULT_PORT = 8096
-
-_CHUNK_LOG_INTERVAL_BYTES = 64 * 1024 * 1024
 
 
 class RecordingReceiver:
@@ -43,31 +43,37 @@ class RecordingReceiver:
         @self.app.put("/{_:path}")
         @self.app.post("/{_:path}")
         async def _(request: Request) -> fastapi.Response:
-            dest = self.resolve_destination(request.url.path)
-            if dest is None:
+            candidate = self.resolve_destination(request.url.path)
+            if candidate is None:
                 return fastapi.responses.JSONResponse(
                     status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-                    content={"detail": "path escapes the recording directory"},
+                    content={"detail": "invalid recording path"},
                 )
-            dest.parent.mkdir(parents=True, exist_ok=True)
             total = 0
             try:
-                with open(dest, "wb") as out:
-                    async for chunk in request.stream():
-                        out.write(chunk)
-                        total += len(chunk)
-            except (ClientDisconnect, OSError) as exc:
+                out, dest = await anyio.to_thread.run_sync(self.open_unique, candidate)
+            except OSError as exc:
+                return _write_failure(candidate, exc)
+            try:
+                async for chunk in request.stream():
+                    await anyio.to_thread.run_sync(out.write, chunk)
+                    total += len(chunk)
+            except ClientDisconnect:
                 # A dropped sender is expected; the fMP4 prefix stays playable.
-                print(f"{dest}: connection ended early after {total} bytes ({exc!r})")
+                print(f"{dest}: connection ended early after {total} bytes")
+            except OSError as exc:
+                return _write_failure(dest, exc)
+            finally:
+                await anyio.to_thread.run_sync(out.close)
             print(f"{dest} <- {total} bytes")
             return fastapi.Response(status_code=fastapi.status.HTTP_201_CREATED)
 
     def resolve_destination(self, url_path: str) -> Path | None:
-        """Map a request URL path to a safe destination file under ``root``.
+        """Map a request URL path to a destination file under ``root``.
 
         Returns None when the path is empty, points at a directory, or escapes
-        ``root``. The ``.mp4`` suffix is enforced and an existing file is never
-        overwritten — a numeric suffix is appended instead.
+        ``root``. The ``.mp4`` suffix is enforced. The returned path is a
+        candidate only — :meth:`open_unique` performs the collision-free create.
 
         :param url_path: The path component of the request URL.
         """
@@ -81,17 +87,39 @@ class RecordingReceiver:
         dest = (self.root / rel).resolve()
         if not dest.is_relative_to(self.root) or dest == self.root:
             return None
+        return dest
+
+    def open_unique(self, dest: Path) -> tuple[BinaryIO, Path]:
+        """Atomically create and open a new file at ``dest`` for writing.
+
+        An existing file is never overwritten: on collision a ``-N`` suffix is
+        appended and the create retried (``O_EXCL``, so concurrent uploads to
+        the same path each get their own file).
+
+        :param dest: The candidate path from :meth:`resolve_destination`.
+        """
+        dest.parent.mkdir(parents=True, exist_ok=True)
         base = dest
         counter = 1
-        while dest.exists():
-            dest = base.with_name(f"{base.stem}-{counter}{base.suffix}")
-            counter += 1
-        return dest
+        while True:
+            try:
+                return open(dest, "xb"), dest
+            except FileExistsError:
+                dest = base.with_name(f"{base.stem}-{counter}{base.suffix}")
+                counter += 1
 
     def serve(self, host: str = "0.0.0.0", port: int = RECORDING_RECEIVER_DEFAULT_PORT):
         self.root.mkdir(parents=True, exist_ok=True)
         print(f"recording receiver on :{port} -> {self.root}")
         uvicorn.run(self.app, host=host, port=port)
+
+
+def _write_failure(dest: Path, exc: OSError) -> fastapi.responses.JSONResponse:
+    print(f"{dest}: write failed ({exc})")
+    return fastapi.responses.JSONResponse(
+        status_code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
+        content={"detail": f"failed to write recording: {exc}"},
+    )
 
 
 @plac.annotations(

--- a/src/tcode_api/servicer/recording_receiver.py
+++ b/src/tcode_api/servicer/recording_receiver.py
@@ -1,0 +1,112 @@
+"""Receiver for robot camera remote recordings.
+
+The counterpart of trilo-cam's ``POST /cameras/{name}/remote-recording/start``:
+the robot streams a fragmented MP4 over HTTP PUT/POST and this server writes it
+to disk as it arrives, so large recordings live on the fleet controller instead
+of the robot's limited storage.
+"""
+
+from pathlib import Path
+
+import fastapi
+import plac  # type: ignore [import-untyped]
+import uvicorn
+from fastapi import FastAPI, Request
+from starlette.requests import ClientDisconnect
+
+RECORDING_RECEIVER_DEFAULT_PORT = 8096
+
+_CHUNK_LOG_INTERVAL_BYTES = 64 * 1024 * 1024
+
+
+class RecordingReceiver:
+    """Accepts streamed recordings from robot cameras and writes them to disk.
+
+    Start a remote recording pointing at this server, e.g.::
+
+        POST http://<rcm>:8095/api/v1/cameras/CAM_POS_X/remote-recording/start
+        {"url": "http://<fleet-controller>:8096/robot1/CAM_POS_X.mp4",
+         "max_duration_s": 600}
+
+    The request path becomes the file path under ``root`` (sanitized, ``.mp4``
+    enforced, existing files never overwritten). Because the body is a
+    fragmented MP4 written incrementally, a recording interrupted mid-stream
+    still leaves a playable file prefix.
+
+    :param root: Directory recordings are written into.
+    """
+
+    def __init__(self, root: Path | str):
+        self.root = Path(root).resolve()
+        self.app = FastAPI()
+
+        @self.app.put("/{_:path}")
+        @self.app.post("/{_:path}")
+        async def _(request: Request) -> fastapi.Response:
+            dest = self.resolve_destination(request.url.path)
+            if dest is None:
+                return fastapi.responses.JSONResponse(
+                    status_code=fastapi.status.HTTP_400_BAD_REQUEST,
+                    content={"detail": "path escapes the recording directory"},
+                )
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            total = 0
+            try:
+                with open(dest, "wb") as out:
+                    async for chunk in request.stream():
+                        out.write(chunk)
+                        total += len(chunk)
+            except (ClientDisconnect, OSError) as exc:
+                # A dropped sender is expected; the fMP4 prefix stays playable.
+                print(f"{dest}: connection ended early after {total} bytes ({exc!r})")
+            print(f"{dest} <- {total} bytes")
+            return fastapi.Response(status_code=fastapi.status.HTTP_201_CREATED)
+
+    def resolve_destination(self, url_path: str) -> Path | None:
+        """Map a request URL path to a safe destination file under ``root``.
+
+        Returns None when the path is empty, points at a directory, or escapes
+        ``root``. The ``.mp4`` suffix is enforced and an existing file is never
+        overwritten — a numeric suffix is appended instead.
+
+        :param url_path: The path component of the request URL.
+        """
+        raw = url_path.lstrip("/")
+        if not raw or raw.endswith("/"):
+            return None
+        try:
+            rel = Path(raw).with_suffix(".mp4")
+        except ValueError:
+            return None
+        dest = (self.root / rel).resolve()
+        if not dest.is_relative_to(self.root) or dest == self.root:
+            return None
+        base = dest
+        counter = 1
+        while dest.exists():
+            dest = base.with_name(f"{base.stem}-{counter}{base.suffix}")
+            counter += 1
+        return dest
+
+    def serve(self, host: str = "0.0.0.0", port: int = RECORDING_RECEIVER_DEFAULT_PORT):
+        self.root.mkdir(parents=True, exist_ok=True)
+        print(f"recording receiver on :{port} -> {self.root}")
+        uvicorn.run(self.app, host=host, port=port)
+
+
+@plac.annotations(
+    directory=plac.Annotation(
+        "Directory recordings are written into", abbrev="d", kind="option", type=Path
+    ),
+    port=plac.Annotation("Port to listen on", abbrev="p", kind="option", type=int),
+)
+def main(
+    directory: Path = Path("./recordings"),
+    port: int = RECORDING_RECEIVER_DEFAULT_PORT,
+) -> None:
+    """Run a standalone recording receiver."""
+    RecordingReceiver(directory).serve(port=port)
+
+
+if __name__ == "__main__":
+    plac.call(main)

--- a/tests/test_servicer/test_recording_receiver.py
+++ b/tests/test_servicer/test_recording_receiver.py
@@ -1,0 +1,108 @@
+"""Tests for the recording receiver."""
+
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+import requests
+import uvicorn
+
+from tcode_api.servicer.recording_receiver import RecordingReceiver
+
+
+class TestResolveDestination(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+        self.receiver = RecordingReceiver(self.root)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_simple_path(self) -> None:
+        dest = self.receiver.resolve_destination("/robot1/CAM_POS_X.mp4")
+        self.assertEqual(dest, self.root / "robot1" / "CAM_POS_X.mp4")
+
+    def test_suffix_is_enforced(self) -> None:
+        dest = self.receiver.resolve_destination("/clip.bin")
+        self.assertEqual(dest, self.root / "clip.mp4")
+
+    def test_missing_suffix_is_added(self) -> None:
+        dest = self.receiver.resolve_destination("/robot1/clip")
+        self.assertEqual(dest, self.root / "robot1" / "clip.mp4")
+
+    def test_empty_and_directory_paths_rejected(self) -> None:
+        self.assertIsNone(self.receiver.resolve_destination("/"))
+        self.assertIsNone(self.receiver.resolve_destination(""))
+        self.assertIsNone(self.receiver.resolve_destination("/robot1/"))
+
+    def test_traversal_escape_rejected(self) -> None:
+        self.assertIsNone(self.receiver.resolve_destination("/../outside.mp4"))
+        self.assertIsNone(self.receiver.resolve_destination("/a/../../outside.mp4"))
+
+    def test_existing_file_never_overwritten(self) -> None:
+        (self.root / "clip.mp4").touch()
+        self.assertEqual(self.receiver.resolve_destination("/clip.mp4"), self.root / "clip-1.mp4")
+        (self.root / "clip-1.mp4").touch()
+        self.assertEqual(self.receiver.resolve_destination("/clip.mp4"), self.root / "clip-2.mp4")
+
+    def test_hyphenated_name_kept_intact(self) -> None:
+        (self.root / "my-clip.mp4").touch()
+        dest = self.receiver.resolve_destination("/my-clip.mp4")
+        self.assertEqual(dest, self.root / "my-clip-1.mp4")
+
+
+class TestReceiverServer(unittest.TestCase):
+    """Round-trips against a live uvicorn instance on an ephemeral port."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls.root = Path(cls._tmp.name).resolve()
+        cls.receiver = RecordingReceiver(cls.root)
+        config = uvicorn.Config(cls.receiver.app, host="127.0.0.1", port=0, log_level="error")
+        cls.server = uvicorn.Server(config)
+        cls.thread = threading.Thread(target=cls.server.run, daemon=True)
+        cls.thread.start()
+        while not cls.server.started:
+            time.sleep(0.01)
+        cls.base = "http://127.0.0.1:{}".format(cls.server.servers[0].sockets[0].getsockname()[1])
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.server.should_exit = True
+        cls.thread.join(timeout=5)
+        cls._tmp.cleanup()
+
+    def test_put_with_content_length(self) -> None:
+        payload = b"x" * 200_000
+        response = requests.put(f"{self.base}/robot1/CAM_POS_X.mp4", data=payload, timeout=5)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual((self.root / "robot1" / "CAM_POS_X.mp4").read_bytes(), payload)
+
+    def test_put_chunked(self) -> None:
+        chunks = [b"a" * 1000, b"b" * 1000, b"c" * 17]
+        response = requests.put(f"{self.base}/chunked.mp4", data=iter(chunks), timeout=5)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual((self.root / "chunked.mp4").read_bytes(), b"".join(chunks))
+
+    def test_post_works_too(self) -> None:
+        response = requests.post(f"{self.base}/posted.mp4", data=b"hello", timeout=5)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual((self.root / "posted.mp4").read_bytes(), b"hello")
+
+    def test_second_upload_gets_new_name(self) -> None:
+        requests.put(f"{self.base}/dup.mp4", data=b"first", timeout=5)
+        requests.put(f"{self.base}/dup.mp4", data=b"second", timeout=5)
+        self.assertEqual((self.root / "dup.mp4").read_bytes(), b"first")
+        self.assertEqual((self.root / "dup-1.mp4").read_bytes(), b"second")
+
+    def test_bad_path_rejected(self) -> None:
+        response = requests.put(f"{self.base}/", data=b"x", timeout=5)
+        self.assertEqual(response.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_servicer/test_recording_receiver.py
+++ b/tests/test_servicer/test_recording_receiver.py
@@ -42,16 +42,34 @@ class TestResolveDestination(unittest.TestCase):
         self.assertIsNone(self.receiver.resolve_destination("/../outside.mp4"))
         self.assertIsNone(self.receiver.resolve_destination("/a/../../outside.mp4"))
 
+
+class TestOpenUnique(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+        self.receiver = RecordingReceiver(self.root)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _open(self, name: str) -> Path:
+        out, dest = self.receiver.open_unique(self.root / name)
+        out.close()
+        return dest
+
     def test_existing_file_never_overwritten(self) -> None:
-        (self.root / "clip.mp4").touch()
-        self.assertEqual(self.receiver.resolve_destination("/clip.mp4"), self.root / "clip-1.mp4")
-        (self.root / "clip-1.mp4").touch()
-        self.assertEqual(self.receiver.resolve_destination("/clip.mp4"), self.root / "clip-2.mp4")
+        self.assertEqual(self._open("clip.mp4"), self.root / "clip.mp4")
+        self.assertEqual(self._open("clip.mp4"), self.root / "clip-1.mp4")
+        self.assertEqual(self._open("clip.mp4"), self.root / "clip-2.mp4")
 
     def test_hyphenated_name_kept_intact(self) -> None:
-        (self.root / "my-clip.mp4").touch()
-        dest = self.receiver.resolve_destination("/my-clip.mp4")
-        self.assertEqual(dest, self.root / "my-clip-1.mp4")
+        self.assertEqual(self._open("my-clip.mp4"), self.root / "my-clip.mp4")
+        self.assertEqual(self._open("my-clip.mp4"), self.root / "my-clip-1.mp4")
+
+    def test_creates_parent_directories(self) -> None:
+        dest = self._open("a/b/clip.mp4")
+        self.assertEqual(dest, self.root / "a" / "b" / "clip.mp4")
+        self.assertTrue(dest.exists())
 
 
 class TestReceiverServer(unittest.TestCase):
@@ -66,7 +84,10 @@ class TestReceiverServer(unittest.TestCase):
         cls.server = uvicorn.Server(config)
         cls.thread = threading.Thread(target=cls.server.run, daemon=True)
         cls.thread.start()
+        deadline = time.monotonic() + 10
         while not cls.server.started:
+            if time.monotonic() > deadline:
+                raise RuntimeError("uvicorn failed to start within 10 s")
             time.sleep(0.01)
         cls.base = "http://127.0.0.1:{}".format(cls.server.servers[0].sockets[0].getsockname()[1])
 

--- a/uv.lock
+++ b/uv.lock
@@ -1484,7 +1484,7 @@ wheels = [
 
 [[package]]
 name = "tcode-api"
-version = "1.41.0"
+version = "1.42.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Fleet-controller counterpart of trilo-cam's `POST /cameras/{name}/remote-recording/start` (trilobot-cam#7): the robot streams a fragmented MP4 over HTTP and this writes it to disk, so large recordings land here instead of the RCM's limited /data.

- `tcode_api.servicer.recording_receiver.RecordingReceiver` — FastAPI app; PUT/POST path maps to a file under the root dir (path-confined, `.mp4` enforced, existing files never overwritten). Streamed writes, so an interrupted push still leaves a playable fMP4 prefix.
- CLI: `python -m tcode_api.servicer.recording_receiver --directory ./recordings --port 8096`
- Docs added to the integrator page (it's the other side of the camera remote-recording flow, as `TCodeIntegratorBase` is for `SEND_WEBHOOK`).
- 12 tests incl. live uvicorn round-trips (Content-Length + chunked).

Version bumped 1.41.0 → 1.42.0; may need re-bumping depending on merge order with #81/#82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)